### PR TITLE
FLPG-166: support orgid from request query params

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,7 @@ build/Release
 # Dependency directory
 # https://www.npmjs.org/doc/misc/npm-faq.html#should-i-check-my-node_modules-folder-into-git
 node_modules
+
+# Webstorm
+.idea
+

--- a/client.js
+++ b/client.js
@@ -77,7 +77,7 @@ Client.prototype.authorizationUrl = function(req, state) {
 
     // If request has "org_id" query param, include that with acr values.
     if (orgId)
-        acr_values += `orgId:${orgId}`;
+        acr_values += ` orgId:${orgId}`;
 
     var config = this.config,
         params = extend({}, {

--- a/client.js
+++ b/client.js
@@ -72,9 +72,16 @@ Client.prototype.callbackUrl = function(req) {
 };
 
 Client.prototype.authorizationUrl = function(req, state) {
+    var acr_values = config.acr_values.join(' ');
+    var orgId = req.query['org_id'];
+
+    // If request has "org_id" query param, include that with acr values.
+    if (orgId)
+        acr_values += `orgId:${orgId}`;
+
     var config = this.config,
         params = extend({}, {
-            acr_values: config.acr_values.join(' '),
+            acr_values: acr_values,
             state: state,
             response_type: 'code',
             client_id: config.client_id,


### PR DESCRIPTION
**Story/Card:**

[FLPG-166](https://frontlinetechnologies.atlassian.net/browse/FLPG-166)

**What does this PR do?**
This change detects whether org_id is specified in the request query parameters. Iff so, we pass that along as an ACR key-value pair to IDM so that it can react appropriately.

**Where should reviewer start?**
Consider that links sent out by e-mail for C&C will soon include the user's org-id as a query param ("org_id", specifically). This code should be able to pick that out and run with it.

**Image showing how you feel about this PR [click here for giphy]:(http://giphy.com)**
https://i.imgur.com/T8dvYWH.mp4
