### PR TITLE
FLPG-166: support orgId from query params

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,7 @@ build/Release
 # Dependency directory
 # https://www.npmjs.org/doc/misc/npm-faq.html#should-i-check-my-node_modules-folder-into-git
 node_modules
+
+# IDEA
+.idea
+

--- a/client.js
+++ b/client.js
@@ -73,8 +73,16 @@ Client.prototype.callbackUrl = function(req) {
 
 Client.prototype.authorizationUrl = function(req, state) {
     var config = this.config,
-        params = extend({}, {
-            acr_values: config.acr_values.join(' '),
+    acrValues  = this.config.acr_values ? this.config.acr_values.slice() : [], // array copy
+    orgId      = req.query['org_id'];
+
+    // If org_id provided by request, include it in acr table.
+    if (orgId) {
+        acrValues.push(`orgId:${orgId}`);
+    }
+
+    var params = extend({}, {
+            acr_values: acrValues.join(' '),
             state: state,
             response_type: 'code',
             client_id: config.client_id,

--- a/client.js
+++ b/client.js
@@ -91,7 +91,7 @@ Client.prototype.authorizationUrl = function(req, state) {
         }
         if (newAcrEntries) {
             for (var x in newAcrEntries) {
-                if (newAcrEntries.hasOwnProperty(x)) {
+                if (newAcrEntries.hasOwnProperty(x) && newAcrEntries[x]) {
                     // Should this be passed through encodeURIComponent?
                     acrValues.push(`${x}:${newAcrEntries[x].toString()}`.trim());
                 }

--- a/strategy.js
+++ b/strategy.js
@@ -46,7 +46,7 @@ function Strategy(identifier, config) {
         // create a defensive copy of array,
         // just to ensure that the user's initial
         // config doesn't get messed up.
-        config.acr_appenders = config.acr_appenders.splice();
+        config.acr_appenders = config.acr_appenders.slice();
     } else {
         config.acr_appenders = [];
     }

--- a/strategy.js
+++ b/strategy.js
@@ -21,6 +21,36 @@ function Strategy(identifier, config) {
         };
     }
 
+    if(!config.acr_values) {
+        config.acr_values = [];
+    }
+
+    // Users may specify any number of functions as ACR Appender callbacks.
+    // Each of these functions will be called with the request object and state,
+    // and should return an object representing key-value pairs that should be
+    // appended to the ACR table.
+    //
+    // Example of such a function:
+    // function(req, state) {
+    //     var acr = {foo:'bar', state: state};
+    //     if (req.query['org_id']) {
+    //         acr['orgId'] = req.query['org_id'];
+    //     }
+    //     return acr;
+    // }
+    //
+    // Callbacks that are sufficiently complex should implement their own error-handling logic,
+    // as any uncaught exceptions thrown by these callbacks will be entirely discarded by this
+    // library.
+    if (Array.isArray(config.acr_appenders)) {
+        // create a defensive copy of array,
+        // just to ensure that the user's initial
+        // config doesn't get messed up.
+        config.acr_appenders = config.acr_appenders.splice();
+    } else {
+        config.acr_appenders = [];
+    }
+
     passport.Strategy.call(this);
 
     this.name = identifier;


### PR DESCRIPTION
**Story/Card:**

[FLPG-166](https://frontlinetechnologies.atlassian.net/browse/FLPG-166)

**What does this PR do?**
This change detects whether org_id is specified in the request query parameters. Iff so, we pass that along as an ACR key-value pair to IDM so that it can react appropriately.

**Where should reviewer start?**
Consider that links sent out by e-mail for C&C will soon include the user's org-id as a query param ("org_id", specifically). This code should be able to pick that out and run with it.

**Image showing how you feel about this PR [click here for giphy]:(http://giphy.com)**
https://i.imgur.com/T8dvYWH.mp4
